### PR TITLE
Feature: Multi-server improvements for destination Monitoring

### DIFF
--- a/chainstate/monitor_client.go
+++ b/chainstate/monitor_client.go
@@ -83,8 +83,9 @@ func (a *AgentClient) SetFilter(regex string, bloomFilter *BloomProcessorFilter)
 	return a.Client.Publish("set_filter", data)
 }
 
+// newCentrifugeClient will create a new Centrifuge using the provided handler and default configurations
 func newCentrifugeClient(wsURL string, handler whatsonchain.SocketHandler) MonitorClient {
-	c := centrifuge.NewJsonClient(wsURL, centrifuge.DefaultConfig())
+	c := centrifuge.NewJsonClient(wsURL, centrifuge.DefaultConfig()) // todo: use our own defaults/custom options
 
 	c.OnConnect(handler)
 	c.OnDisconnect(handler)

--- a/client_options.go
+++ b/client_options.go
@@ -97,11 +97,12 @@ func defaultClientOptions() *clientOptions {
 		taskManager: &taskManagerOptions{
 			ClientInterface: nil,
 			cronTasks: map[string]time.Duration{
-				ModelDraftTransaction.String() + "_clean_up":              60 * time.Second,
-				ModelIncomingTransaction.String() + "_process":            30 * time.Second,
-				ModelSyncTransaction.String() + "_" + syncActionBroadcast: 30 * time.Second,
-				ModelSyncTransaction.String() + "_" + syncActionSync:      60 * time.Second,
-				ModelSyncTransaction.String() + "_" + syncActionP2P:       35 * time.Second,
+				ModelDestination.String() + "_monitor":                    taskIntervalMonitorCheck,
+				ModelDraftTransaction.String() + "_clean_up":              taskIntervalDraftCleanup,
+				ModelIncomingTransaction.String() + "_process":            taskIntervalProcessIncomingTxs,
+				ModelSyncTransaction.String() + "_" + syncActionBroadcast: taskIntervalSyncActionBroadcast,
+				ModelSyncTransaction.String() + "_" + syncActionP2P:       taskIntervalSyncActionP2P,
+				ModelSyncTransaction.String() + "_" + syncActionSync:      taskIntervalSyncActionSync,
 			},
 		},
 

--- a/definitions.go
+++ b/definitions.go
@@ -15,7 +15,7 @@ const (
 	defaultDraftTxExpiresIn        = 20 * time.Second  // Default TTL for draft transactions
 	defaultHTTPTimeout             = 20 * time.Second  // Default timeout for HTTP requests
 	defaultMonitorHeartbeat        = 60                // in Seconds (heartbeat for active monitor)
-	defaultMonitorHeartbeatMax     = 120               // in Seconds (max out of range time for heartbeat, something is wrong)
+	defaultMonitorHeartbeatMax     = 90                // in Seconds (max out of range time for heartbeat, something is wrong)
 	defaultOverheadSize            = uint64(8)         // 8 bytes is the default overhead in a transaction = 4 bytes version + 4 bytes nLockTime
 	defaultQueryTxTimeout          = 10 * time.Second  // Default timeout for syncing on-chain information
 	defaultSleepForNewBlockHeaders = 30 * time.Second  // Default wait before checking for a new unprocessed block

--- a/definitions.go
+++ b/definitions.go
@@ -14,6 +14,8 @@ const (
 	defaultDatabaseReadTimeout     = 20 * time.Second  // For all "GET" or "SELECT" methods
 	defaultDraftTxExpiresIn        = 20 * time.Second  // Default TTL for draft transactions
 	defaultHTTPTimeout             = 20 * time.Second  // Default timeout for HTTP requests
+	defaultMonitorHeartbeat        = 60                // in Seconds (heartbeat for active monitor)
+	defaultMonitorHeartbeatMax     = 120               // in Seconds (max out of range time for heartbeat, something is wrong)
 	defaultOverheadSize            = uint64(8)         // 8 bytes is the default overhead in a transaction = 4 bytes version + 4 bytes nLockTime
 	defaultQueryTxTimeout          = 10 * time.Second  // Default timeout for syncing on-chain information
 	defaultSleepForNewBlockHeaders = 30 * time.Second  // Default wait before checking for a new unprocessed block
@@ -22,6 +24,16 @@ const (
 	mongoTestVersion               = "4.2.1"           // Mongo Testing Version
 	sqliteTestVersion              = "3.37.0"          // SQLite Testing Version (dummy version for now)
 	version                        = "v0.2.28"         // bux version
+)
+
+// Defaults for task cron jobs (tasks)
+const (
+	taskIntervalDraftCleanup        = 60 * time.Second                      // Default task time for cron jobs (seconds)
+	taskIntervalMonitorCheck        = defaultMonitorHeartbeat * time.Second // Default task time for cron jobs (seconds)
+	taskIntervalProcessIncomingTxs  = 30 * time.Second                      // Default task time for cron jobs (seconds)
+	taskIntervalSyncActionBroadcast = 30 * time.Second                      // Default task time for cron jobs (seconds)
+	taskIntervalSyncActionP2P       = 35 * time.Second                      // Default task time for cron jobs (seconds)
+	taskIntervalSyncActionSync      = 40 * time.Second                      // Default task time for cron jobs (seconds)
 )
 
 // All the base models

--- a/interface.go
+++ b/interface.go
@@ -142,7 +142,6 @@ type TransactionService interface {
 		opts ...ModelOps) (*DraftTransaction, error)
 	RecordTransaction(ctx context.Context, xPubKey, txHex, draftID string,
 		opts ...ModelOps) (*Transaction, error)
-	RecordMonitoredTransaction(ctx context.Context, txHex string, opts ...ModelOps) (*Transaction, error)
 	UpdateTransactionMetadata(ctx context.Context, xPubID, id string, metadata Metadata) (*Transaction, error)
 }
 

--- a/monitor.go
+++ b/monitor.go
@@ -110,7 +110,11 @@ func startDefaultMonitor(ctx context.Context, client ClientInterface, monitor ch
 
 	// Set the cache-key lock for this monitor (with a heartbeat time of now)
 	if len(monitor.GetLockID()) > 0 {
-		return client.Cachestore().Set(ctx, fmt.Sprintf(lockKeyMonitorLockID, monitor.GetLockID()), fmt.Sprintf("%d", time.Now().UTC().Unix()))
+		return client.Cachestore().Set(
+			ctx,
+			fmt.Sprintf(lockKeyMonitorLockID, monitor.GetLockID()),
+			fmt.Sprintf("%d", time.Now().UTC().Unix()),
+		)
 	}
 	return nil
 }

--- a/monitor.go
+++ b/monitor.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strconv"
 	"time"
 
 	"github.com/BuxOrg/bux/chainstate"
@@ -11,17 +12,22 @@ import (
 	"github.com/BuxOrg/bux/utils"
 )
 
+// destinationMonitor is the struct of responses for Monitoring
 type destinationMonitor struct {
 	LockingScript string `json:"locking_script" toml:"locking_script" yaml:"locking_script" bson:"locking_script"`
 }
 
-func (c *Client) loadMonitoredDestinations(ctx context.Context, monitor chainstate.MonitorService) error {
+// loadMonitoredDestinations will load destinations that should be monitored
+func loadMonitoredDestinations(ctx context.Context, client ClientInterface, monitor chainstate.MonitorService) error {
+
+	// Create conditions using the max monitor days
 	conditions := map[string]interface{}{
 		"monitor": map[string]interface{}{
 			"$gt": time.Now().Add(time.Duration(-24*monitor.GetMonitorDays()) * time.Hour),
 		},
 	}
 
+	// Create monitor query with max destinations
 	queryParams := &datastore.QueryParams{
 		Page:          1,
 		PageSize:      monitor.GetMaxNumberOfDestinations(),
@@ -29,21 +35,82 @@ func (c *Client) loadMonitoredDestinations(ctx context.Context, monitor chainsta
 		SortDirection: "desc",
 	}
 
+	// Get all destinations that match the query
 	var destinations []*destinationMonitor
-	if err := c.Datastore().GetModels(
+	if err := client.Datastore().GetModels(
 		ctx, &[]*Destination{}, conditions, queryParams, &destinations, defaultDatabaseReadTimeout,
 	); err != nil && !errors.Is(err, datastore.ErrNoResults) {
 		return err
 	}
 
+	// Loop all destinations and add to Monitor
 	for _, model := range destinations {
-		// todo: skipping the error check?
-		_ = monitor.Processor().Add(utils.P2PKHRegexpString, model.LockingScript)
+		if err := monitor.Processor().Add(utils.P2PKHRegexpString, model.LockingScript); err != nil {
+			return err
+		}
 	}
 
-	if c.options.debug && c.Logger() != nil {
-		c.Logger().Info(ctx, fmt.Sprintf("[MONITOR] Added %d destinations to monitor", len(destinations)))
+	// Debug line
+	if client.IsDebug() && client.Logger() != nil {
+		client.Logger().Info(ctx, fmt.Sprintf("[MONITOR] Added %d destinations to monitor", len(destinations)))
 	}
 
+	return nil
+}
+
+// checkMonitorHeartbeat will check for a Monitor heartbeat key and detect if it's locked or not
+func checkMonitorHeartbeat(ctx context.Context, client ClientInterface, lockID string) (bool, error) {
+
+	// Make sure cachestore is loaded (safety check)
+	cs := client.Cachestore()
+	if cs == nil {
+		return false, nil
+	}
+
+	// Check if there is already a monitor loaded using this unique lock id & detect last heartbeat
+	lastHeartBeatString, _ := cs.Get(ctx, fmt.Sprintf(lockKeyMonitorLockID, lockID))
+	if len(lastHeartBeatString) > 0 { // Monitor has already loaded with this LockID
+
+		currentUnixTime := time.Now().UTC().Unix()
+
+		// Convert the heartbeat and then compare
+		unixTime, err := strconv.Atoi(lastHeartBeatString)
+		if err != nil {
+			return false, err
+		}
+
+		// Heartbeat is good - skip loading the monitor
+		if int64(unixTime+defaultMonitorHeartbeatMax) > currentUnixTime {
+			client.Logger().Info(ctx, fmt.Sprintf("monitor has already been loaded using this lockID: %s last heartbeat: %d", lockID, unixTime))
+			return true, nil
+		} else { // Heartbeat failed the max (out of range) check for the last heart beat
+			client.Logger().Info(ctx, fmt.Sprintf("found monitor lockID: %s but heartbeat is out of range: %d vs %d", lockID, unixTime, currentUnixTime))
+
+			// Continue, and load the monitor...
+		}
+	}
+	return false, nil
+}
+
+// startDefaultMonitor will create a handler, start monitor, and store the first heartbeat
+func startDefaultMonitor(ctx context.Context, client ClientInterface, monitor chainstate.MonitorService) error {
+
+	// Create a handler and load destinations if option has been set
+	handler := NewMonitorHandler(ctx, client, monitor)
+	if client.Chainstate().Monitor().LoadMonitoredDestinations() {
+		if err := loadMonitoredDestinations(ctx, client, monitor); err != nil {
+			return err
+		}
+	}
+
+	// Start the monitor
+	if err := monitor.Start(ctx, &handler); err != nil {
+		return err
+	}
+
+	// Set the cache-key lock for this monitor (with a heartbeat time of now)
+	if len(monitor.GetLockID()) > 0 {
+		return client.Cachestore().Set(ctx, fmt.Sprintf(lockKeyMonitorLockID, monitor.GetLockID()), fmt.Sprintf("%d", time.Now().UTC().Unix()))
+	}
 	return nil
 }

--- a/monitor_event_handler.go
+++ b/monitor_event_handler.go
@@ -18,13 +18,13 @@ import (
 
 // MonitorEventHandler for handling transaction events from a monitor
 type MonitorEventHandler struct {
+	blockSyncChannel chan bool
 	buxClient        ClientInterface
 	ctx              context.Context
 	debug            bool
 	limit            *limiter.ConcurrencyLimiter
 	logger           chainstate.Logger
 	monitor          chainstate.MonitorService
-	blockSyncChannel chan bool
 }
 
 type blockSubscriptionHandler struct {
@@ -281,12 +281,12 @@ func (h *MonitorEventHandler) OnPublish(subscription *centrifuge.Subscription, e
 				return
 			}
 			bh := bc.BlockHeader{
-				HashPrevBlock:  []byte(bi.PreviousBlockHash),
-				HashMerkleRoot: []byte(bi.MerkleRoot),
-				Nonce:          uint32(bi.Nonce),
-				Version:        uint32(bi.Version),
-				Time:           uint32(bi.Time),
 				Bits:           []byte(bi.Bits),
+				HashMerkleRoot: []byte(bi.MerkleRoot),
+				HashPrevBlock:  []byte(bi.PreviousBlockHash),
+				Nonce:          uint32(bi.Nonce),
+				Time:           uint32(bi.Time),
+				Version:        uint32(bi.Version),
 			}
 			if _, err = h.buxClient.RecordBlockHeader(
 				h.ctx, bi.Hash, uint32(bi.Height), bh,

--- a/tasks.go
+++ b/tasks.go
@@ -3,6 +3,7 @@ package bux
 import (
 	"context"
 	"errors"
+	"fmt"
 	"time"
 
 	"github.com/BuxOrg/bux/datastore"
@@ -101,4 +102,33 @@ func taskSyncTransactions(ctx context.Context, logClient logger.Interface, opts 
 		return nil
 	}
 	return err
+}
+
+// taskCheckActiveMonitor will check for an active Monitor locally and globally
+func taskCheckActiveMonitor(ctx context.Context, logClient logger.Interface, client ClientInterface) error {
+	logClient.Info(ctx, "running check active monitor task...")
+
+	cs := client.Cachestore()
+	m := client.Chainstate().Monitor()
+	if cs != nil && m != nil { // Do we have a cachestore and Monitor?
+
+		// Do we have an active Monitor and socket connection? (locally we are the primary monitor)
+		if m.IsConnected() { // Set a new heartbeat timestamp for the active monitor
+			return cs.Set(ctx, fmt.Sprintf(lockKeyMonitorLockID, m.GetLockID()), fmt.Sprintf("%d", time.Now().UTC().Unix()))
+		}
+
+		// Check for an active Monitor (globally) (we are not the primary monitor potentially)
+		locked, err := checkMonitorHeartbeat(ctx, client, m.GetLockID())
+		if err != nil {
+			return err
+		} else if locked {
+			return nil
+		}
+
+		// Start the monitor! - Starts the monitor and creates a long-lasting lock
+		return startDefaultMonitor(ctx, client, m)
+	}
+
+	// No cachestore or monitor found, just ignore
+	return nil
 }

--- a/tasks.go
+++ b/tasks.go
@@ -117,6 +117,8 @@ func taskCheckActiveMonitor(ctx context.Context, logClient logger.Interface, cli
 			return cs.Set(ctx, fmt.Sprintf(lockKeyMonitorLockID, m.GetLockID()), fmt.Sprintf("%d", time.Now().UTC().Unix()))
 		}
 
+		// todo: add a MachineID to detect multi-machines using same LockID?
+
 		// Check for an active Monitor (globally) (we are not the primary monitor potentially)
 		locked, err := checkMonitorHeartbeat(ctx, client, m.GetLockID())
 		if err != nil {


### PR DESCRIPTION
- Rudimentary multi-server support using Cachestore and heartbeat
- Supports a `LockID` and `heartbeat` time
- Runs a task every X seconds looking for an active monitor
- Record monitor tx is now an internal method (not public anymore)