### PR TITLE
Added grouping of transactions per xpub when broadcasting and run in parallel

### DIFF
--- a/tasks.go
+++ b/tasks.go
@@ -72,7 +72,7 @@ func taskBroadcastTransactions(ctx context.Context, logClient zLogger.GormLogger
 
 	logClient.Info(ctx, "running broadcast transaction(s) task...")
 
-	err := processBroadcastTransactions(ctx, 10, opts...)
+	err := processBroadcastTransactions(ctx, 1000, opts...)
 	if err == nil || errors.Is(err, datastore.ErrNoResults) {
 		return nil
 	}


### PR DESCRIPTION
<!-- thank you for your contribution! ❤️  -->

Hi all, could you please review this carefully as this solves some pain points we are having in TonicPow, but it does change the broadcasting quite a bit.