### PR TITLE
fix: quickfix for duplication of UTXO in incoming transactions

### DIFF
--- a/model_transactions.go
+++ b/model_transactions.go
@@ -69,6 +69,7 @@ type Transaction struct {
 	transactionService transactionInterface `gorm:"-" bson:"-"` // Used for interfacing methods
 	utxos              []Utxo               `gorm:"-" bson:"-"` // json:"destinations,omitempty"
 	xPubID             string               `gorm:"-" bson:"-"` // XPub of the user registering this transaction
+	beforeCreateCalled bool                 `gorm:"-" bson:"-"` // Private information that the transaction lifecycle method BeforeCreate was already called
 }
 
 // newTransactionBase creates the standard transaction model base
@@ -451,6 +452,11 @@ func (m *Transaction) getValues() (outputValue uint64, fee uint64) {
 // BeforeCreating will fire before the model is being inserted into the Datastore
 func (m *Transaction) BeforeCreating(ctx context.Context) error {
 
+	if m.beforeCreateCalled {
+		m.DebugLog("skipping: " + m.Name() + " BeforeCreating hook, because already called")
+		return nil
+	}
+
 	m.DebugLog("starting: " + m.Name() + " BeforeCreating hook...")
 
 	// Test for required field(s)
@@ -543,6 +549,7 @@ func (m *Transaction) BeforeCreating(ctx context.Context) error {
 	}
 
 	m.DebugLog("end: " + m.Name() + " BeforeCreating hook")
+	m.beforeCreateCalled = true
 	return nil
 }
 


### PR DESCRIPTION
BeforeCreate lifecycle function is called twice when synchronising with blockchain and getting incoming transaction.

First time it is in [action_transaction.go:191](https://github.com/BuxOrg/bux/blob/master/action_transaction.go#L191) where it is called with such a comment:
`run before create to see whether xpub_in_ids or xpub_out_ids is set`
And second time it is called during save as a part of standard lifecycle in [model_save.go:33](https://github.com/BuxOrg/bux/blob/master/model_save.go#L33)