### PR TITLE
feat: remove resetting transaction metadata before save

### DIFF
--- a/model_transactions.go
+++ b/model_transactions.go
@@ -381,8 +381,6 @@ func (m *Transaction) Save(ctx context.Context) (err error) {
 			for key, value := range m.Metadata {
 				m.XpubMetadata[m.xPubID][key] = value
 			}
-			// todo will this overwrite the global metadata ?
-			m.Metadata = nil
 		} else {
 			m.DebugLog("xPub id is missing from transaction, cannot store metadata")
 		}


### PR DESCRIPTION
<!-- thank you for your contribution! ❤️  -->
Description
-----

- Removed transaction metadata resetting. This change is necessary if we want to save information in metadata but we want it to readable by both users (sender and receiver). Until now If we send data in metadata by RecordTransaction method it will be saved but in xpub_metada with sender pub_id as key.
