### PR TITLE
fix: fixes empty sender's paymail

### DIFF
--- a/action_paymails.go
+++ b/action_paymails.go
@@ -69,7 +69,7 @@ func (c *Client) GetPaymailAddressesByXPubID(ctx context.Context, xPubID string,
 	conditions *map[string]interface{}, queryParams *datastore.QueryParams) ([]*PaymailAddress, error) {
 
 	// Check for existing NewRelic transaction
-	ctx = c.GetOrStartTxn(ctx, "get_transaction")
+	ctx = c.GetOrStartTxn(ctx, "get_paymail_by_xpub")
 
 	if conditions == nil {
 		*conditions = make(map[string]interface{})

--- a/model_transaction_config_test.go
+++ b/model_transaction_config_test.go
@@ -331,7 +331,7 @@ func TestTransactionConfig_processOutput(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, satoshis, out.Satoshis)
 		assert.Equal(t, testAlias+"@"+testDomain, out.To)
-		assert.Equal(t, "", out.PaymailP4.FromPaymail)
+		assert.Equal(t, defaultSenderPaymail, out.PaymailP4.FromPaymail)
 		assert.Equal(t, testAlias, out.PaymailP4.Alias)
 		assert.Equal(t, testDomain, out.PaymailP4.Domain)
 		assert.Equal(t, "", out.PaymailP4.Note)


### PR DESCRIPTION
Fixes empty paymail in outgoing transactions.
Before:
<img width="487" alt="Screenshot 2023-07-05 at 11 27 04" src="https://github.com/BuxOrg/bux/assets/123358309/ebc1955a-c979-4815-a61d-9dc67b98c40e">
After:
<img width="488" alt="Screenshot 2023-07-05 at 11 26 48" src="https://github.com/BuxOrg/bux/assets/123358309/420c90e5-e826-4641-b96c-68d4189df5d2">
Handchash was used as the recipient for test transactions.
