### PR TITLE
Perf speed up tx broadcasting

### DIFF
--- a/chainstate/broadcast_providers.go
+++ b/chainstate/broadcast_providers.go
@@ -1,0 +1,146 @@
+package chainstate
+
+import (
+	"context"
+	"errors"
+	"strings"
+
+	"github.com/mrz1836/go-nownodes"
+	"github.com/tonicpow/go-minercraft"
+)
+
+// generic broadcast provider
+type txBroadcastProvider interface {
+	getName() string
+	broadcast(ctx context.Context, c *Client) error
+}
+
+// mAPI provider
+type mapiBroadcastProvider struct {
+	miner   *Miner
+	id, hex string
+}
+
+func (provider mapiBroadcastProvider) getName() string {
+	return provider.miner.Miner.Name
+}
+
+func (provider mapiBroadcastProvider) broadcast(ctx context.Context, c *Client) error {
+	return broadcastMAPI(ctx, c, provider.miner.Miner, provider.id, provider.hex)
+}
+
+// broadcastMAPI will broadcast a transaction to a miner using mAPI
+func broadcastMAPI(ctx context.Context, client ClientInterface, miner *minercraft.Miner, id, hex string) error {
+	client.DebugLog("executing broadcast request in mapi using miner: " + miner.Name)
+
+	resp, err := client.Minercraft().SubmitTransaction(ctx, miner, &minercraft.Transaction{
+		CallBackEncryption: "", // todo: allow customizing the payload
+		CallBackToken:      "",
+		CallBackURL:        "",
+		DsCheck:            false,
+		MerkleFormat:       "",
+		MerkleProof:        false,
+		RawTx:              hex,
+	})
+	if err != nil {
+		client.DebugLog("error executing request in mapi using miner: " + miner.Name + " failed: " + err.Error())
+		return err
+	}
+
+	// Something went wrong - got back an id that does not match
+	if resp == nil || !strings.EqualFold(resp.Results.TxID, id) {
+		return errors.New("returned tx id [" + resp.Results.TxID + "] does not match given tx id [" + id + "]")
+	}
+
+	// mAPI success of broadcast
+	if resp.Results.ReturnResult == mAPISuccess {
+		return nil
+	}
+
+	// Check error message (for success error message)
+	if doesErrorContain(resp.Results.ResultDescription, broadcastSuccessErrors) {
+		return nil
+	}
+
+	// We got a potential real error message?
+	return errors.New(resp.Results.ResultDescription)
+}
+
+////
+
+// WhatsOnChain provider
+type whatsOnChainBroadcastProvider struct {
+	id, hex string
+}
+
+func (provider whatsOnChainBroadcastProvider) getName() string {
+	return ProviderWhatsOnChain
+}
+
+func (provider whatsOnChainBroadcastProvider) broadcast(ctx context.Context, c *Client) error {
+	return broadcastWhatsOnChain(ctx, c, provider.id, provider.hex)
+}
+
+// broadcastWhatsOnChain will broadcast a transaction to WhatsOnChain
+func broadcastWhatsOnChain(ctx context.Context, client ClientInterface, id, hex string) error {
+	client.DebugLog("executing broadcast request for " + ProviderWhatsOnChain)
+
+	txID, err := client.WhatsOnChain().BroadcastTx(ctx, hex)
+	if err != nil {
+
+		// Check error message (for success error message)
+		if doesErrorContain(err.Error(), broadcastSuccessErrors) {
+			return nil
+		}
+		return err
+	}
+
+	// Something went wrong - got back an id that does not match
+	if !strings.EqualFold(txID, id) {
+		return errors.New("returned tx id [" + txID + "] does not match given tx id [" + id + "]")
+	}
+
+	// Success
+	return nil
+}
+
+////
+
+// NowNodes provider
+type nowNodesBroadcastProvider struct {
+	uniqueID, txID, hex string
+}
+
+func (provider nowNodesBroadcastProvider) getName() string {
+	return ProviderNowNodes
+}
+
+// Broadcast using NowNodes
+func (provider nowNodesBroadcastProvider) broadcast(ctx context.Context, c *Client) error {
+	return broadcastNowNodes(ctx, c, provider.uniqueID, provider.txID, provider.hex)
+}
+
+// broadcastNowNodes will broadcast a transaction to NowNodes
+func broadcastNowNodes(ctx context.Context, client ClientInterface, uniqueID, txID, hex string) error {
+	client.DebugLog("executing broadcast request for " + ProviderNowNodes)
+
+	result, err := client.NowNodes().SendRawTransaction(ctx, nownodes.BSV, hex, uniqueID)
+	if err != nil {
+
+		// Check error message (for success error message)
+		if doesErrorContain(err.Error(), broadcastSuccessErrors) {
+			return nil
+		}
+		return err
+	}
+
+	// Something went wrong - got back an id that does not match
+	if !strings.EqualFold(result.Result, txID) {
+		return errors.New("returned tx id [" + result.Result + "] does not match given tx id [" + txID + "]")
+	}
+
+	// Success
+	return nil
+}
+
+////

--- a/chainstate/broadcast_utils.go
+++ b/chainstate/broadcast_utils.go
@@ -1,0 +1,71 @@
+package chainstate
+
+import (
+	"strings"
+	"sync"
+)
+
+// struct handle communication with client - returns first successful broadcast
+type broadcastStatus struct {
+	mu          *sync.Mutex
+	complete    bool
+	success     bool
+	syncChannel chan string
+}
+
+func newBroadcastStatus(synchChannel chan string) *broadcastStatus {
+	return &broadcastStatus{complete: false, syncChannel: synchChannel, mu: &sync.Mutex{}}
+}
+
+func (g *broadcastStatus) tryCompleteWithSuccess(fastestProvider string) {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+
+	if !g.complete {
+		g.complete = true
+		g.success = true
+
+		g.syncChannel <- fastestProvider
+		close(g.syncChannel)
+	}
+
+	// g.mu.Unlock() is done by defer
+}
+
+func (g *broadcastStatus) dispose() {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+
+	if !g.complete {
+		g.complete = true
+		close(g.syncChannel) // have to close the channel here to not block client
+	}
+
+	// g.mu.Unlock() is done by defer
+}
+
+// result of single broadcast to provider
+type broadcastResult struct {
+	isError  bool
+	err      error
+	provider string
+}
+
+func newErrorResult(err error, provider string) broadcastResult {
+	return broadcastResult{isError: true, err: err, provider: provider}
+}
+
+func newSuccessResult(provider string) broadcastResult {
+	return broadcastResult{isError: false, provider: provider}
+}
+
+// doesErrorContain will look at a string for a list of strings
+func doesErrorContain(err string, messages []string) bool {
+	lower := strings.ToLower(err)
+	for _, str := range messages {
+		if strings.Contains(lower, str) {
+			return true
+		}
+	}
+	return false
+}

--- a/chainstate/broadcast_utils.go
+++ b/chainstate/broadcast_utils.go
@@ -1,11 +1,12 @@
 package chainstate
 
 import (
+	"fmt"
 	"strings"
 	"sync"
 )
 
-// struct handle communication with client - returns first successful broadcast
+// struct handles communication with the client - returns first successful broadcast
 type broadcastStatus struct {
 	mu          *sync.Mutex
 	complete    bool
@@ -68,4 +69,8 @@ func doesErrorContain(err string, messages []string) bool {
 		}
 	}
 	return false
+}
+
+func debugLog(c ClientInterface, txId, msg string) {
+	c.DebugLog(fmt.Sprintf("[txId: %s]: %s", txId, msg))
 }

--- a/chainstate/mock_minercraft.go
+++ b/chainstate/mock_minercraft.go
@@ -696,3 +696,35 @@ type minerCraftUnreachble struct {
 func (m *minerCraftUnreachble) FeeQuote(context.Context, *minercraft.Miner) (*minercraft.FeeQuoteResponse, error) {
 	return nil, errors.New("minercraft is unreachable")
 }
+
+type minerCraftBroadcastTimeout struct {
+	MinerCraftBase
+}
+
+func (m *minerCraftBroadcastTimeout) SubmitTransaction(_ context.Context, miner *minercraft.Miner,
+	_ *minercraft.Transaction,
+) (*minercraft.SubmitTransactionResponse, error) {
+	time.Sleep(defaultBroadcastTimeOut * 2)
+
+	return &minercraft.SubmitTransactionResponse{
+		JSONEnvelope: minercraft.JSONEnvelope{
+			Miner:     miner,
+			Validated: true,
+			JSONEnvelope: envelope.JSONEnvelope{
+				Payload:  "{\"apiVersion\":\"\",\"timestamp\":\"2022-02-01T17:47:52.518Z\",\"txid\":\"\",\"returnResult\":\"failure\",\"resultDescription\":\"ERROR: Mempool conflict\",\"minerId\":null,\"currentHighestBlockHash\":\"0000000000000000064c900b1fceb316302426aedb2242852530b5e78144f2c1\",\"currentHighestBlockHeight\":724816,\"txSecondMempoolExpiry\":0}",
+				Encoding: utf8Type,
+				MimeType: applicationJSONType,
+			},
+		},
+		Results: &minercraft.SubmissionPayload{
+			APIVersion:                "",
+			CurrentHighestBlockHash:   "0000000000000000064c900b1fceb316302426aedb2242852530b5e78144f2c1",
+			CurrentHighestBlockHeight: 724816,
+			MinerID:                   miner.MinerID,
+			ResultDescription:         "ERROR: Mempool conflict",
+			ReturnResult:              mAPIFailure,
+			Timestamp:                 "2022-02-01T17:47:52.518Z",
+			TxID:                      "",
+		},
+	}, nil
+}

--- a/chainstate/mock_nownodes_test.go
+++ b/chainstate/mock_nownodes_test.go
@@ -3,6 +3,7 @@ package chainstate
 import (
 	"context"
 	"errors"
+	"time"
 
 	"github.com/mrz1836/go-nownodes"
 )
@@ -42,13 +43,14 @@ type nowNodesTxOnChain struct {
 }
 
 func (n *nowNodesTxOnChain) SendRawTransaction(context.Context, nownodes.Blockchain,
-	string, string) (*nownodes.BroadcastResult, error) {
+	string, string,
+) (*nownodes.BroadcastResult, error) {
 	return nil, errors.New("257: txn-already-known")
 }
 
 func (n *nowNodesTxOnChain) GetTransaction(_ context.Context, _ nownodes.Blockchain,
-	txID string) (*nownodes.TransactionInfo, error) {
-
+	txID string,
+) (*nownodes.TransactionInfo, error) {
 	if txID == onChainExample1TxID {
 		return &nownodes.TransactionInfo{
 			BlockHash:     "0000000000000000015122781ab51d57b26a09518630b882f67f1b08d841979d",
@@ -117,7 +119,8 @@ type nowNodesBroadcastSuccess struct {
 }
 
 func (n *nowNodesBroadcastSuccess) SendRawTransaction(_ context.Context, _ nownodes.Blockchain,
-	_ string, id string) (*nownodes.BroadcastResult, error) {
+	_ string, id string,
+) (*nownodes.BroadcastResult, error) {
 	return &nownodes.BroadcastResult{
 		ID:     id,
 		Result: id,
@@ -129,7 +132,8 @@ type nowNodeInMempool struct {
 }
 
 func (n *nowNodeInMempool) SendRawTransaction(context.Context, nownodes.Blockchain,
-	string, string) (*nownodes.BroadcastResult, error) {
+	string, string,
+) (*nownodes.BroadcastResult, error) {
 	return nil, errors.New("257: txn-already-known")
 }
 
@@ -138,11 +142,24 @@ type nowNodesTxNotFound struct {
 }
 
 func (n *nowNodesTxNotFound) SendRawTransaction(context.Context, nownodes.Blockchain,
-	string, string) (*nownodes.BroadcastResult, error) {
+	string, string,
+) (*nownodes.BroadcastResult, error) {
 	return nil, errors.New("56: mempool conflict")
 }
 
 func (n *nowNodesTxNotFound) GetTransaction(_ context.Context, _ nownodes.Blockchain,
-	txID string) (*nownodes.TransactionInfo, error) {
+	txID string,
+) (*nownodes.TransactionInfo, error) {
 	return nil, errors.New("Transaction '" + txID + "' not found")
+}
+
+type nowNodesBroadcastTimeout struct {
+	nowNodesBase
+}
+
+func (n *nowNodesBroadcastTimeout) SendRawTransaction(context.Context, nownodes.Blockchain,
+	string, string,
+) (*nownodes.BroadcastResult, error) {
+	time.Sleep(defaultBroadcastTimeOut * 2)
+	return nil, errors.New("257: txn-already-known")
 }

--- a/chainstate/mock_whatsonchain_test.go
+++ b/chainstate/mock_whatsonchain_test.go
@@ -3,6 +3,7 @@ package chainstate
 import (
 	"context"
 	"errors"
+	"time"
 
 	"github.com/centrifugal/centrifuge-go"
 	"github.com/libsv/go-bt/v2"
@@ -192,7 +193,6 @@ func (w *whatsOnChainTxOnChain) BroadcastTx(context.Context, string) (string, er
 }
 
 func (w *whatsOnChainTxOnChain) GetTxByHash(_ context.Context, hash string) (txInfo *whatsonchain.TxInfo, err error) {
-
 	if hash == onChainExample1TxID {
 		txInfo = &whatsonchain.TxInfo{
 			BlockHash:     onChainExample1BlockHash,
@@ -258,4 +258,13 @@ func (w *whatsOnChainTxNotFound) GetTxByHash(context.Context, string) (txInfo *w
 
 func (w *whatsOnChainTxNotFound) BroadcastTx(context.Context, string) (string, error) {
 	return "", errors.New("unexpected response code 500: mempool conflict")
+}
+
+type whatsOnChainBroadcastTimeout struct {
+	whatsOnChainBase
+}
+
+func (w *whatsOnChainBroadcastTimeout) BroadcastTx(_ context.Context, _ string) (string, error) {
+	time.Sleep(defaultBroadcastTimeOut * 2)
+	return "", errors.New("unexpected response code 500: 257: txn-already-known")
 }


### PR DESCRIPTION
 change broadcasting logic:
- run broadcasting to providers in separate go routine
- register fastest successful broadcast on the synchronization channel
- response to end-client as soon as the fastest provider records the broadcast