### PR TITLE
fix(BUX-136): internal paymail transaction bug

### DIFF
--- a/paymail_service_provider.go
+++ b/paymail_service_provider.go
@@ -147,9 +147,14 @@ func (p *PaymailDefaultServiceProvider) RecordTransaction(ctx context.Context,
 	metadata[p2pMetadataField] = p2pTx.MetaData
 	metadata[ReferenceIDField] = p2pTx.Reference
 
+	var draftID string
+	if tx, _ := p.client.GetTransactionByHex(ctx, p2pTx.Hex); tx != nil {
+		draftID = tx.DraftID
+	}
+
 	// Record the transaction
 	transaction, err := p.client.RecordTransaction(
-		ctx, "", p2pTx.Hex, "", []ModelOps{WithMetadatas(metadata)}...,
+		ctx, "", p2pTx.Hex, draftID, []ModelOps{WithMetadatas(metadata)}...,
 	)
 	// do not return an error if we already have the transaction
 	if err != nil && !errors.Is(err, datastore.ErrDuplicateKey) {


### PR DESCRIPTION
Each incoming paymail transaction is considered obviously external(DRAFT_ID == NIL), which is not correct, since the case bux to bux transactions is not taken into account.