### PR TITLE
Feat: add new transaction task

### DIFF
--- a/client_options.go
+++ b/client_options.go
@@ -109,6 +109,7 @@ func defaultClientOptions() *clientOptions {
 				ModelSyncTransaction.String() + "_" + syncActionBroadcast: taskIntervalSyncActionBroadcast,
 				ModelSyncTransaction.String() + "_" + syncActionP2P:       taskIntervalSyncActionP2P,
 				ModelSyncTransaction.String() + "_" + syncActionSync:      taskIntervalSyncActionSync,
+				ModelTransaction.String() + "_" + TransactionActionCheck:  taskIntervalTransactionCheck,
 			},
 		},
 

--- a/definitions.go
+++ b/definitions.go
@@ -36,6 +36,7 @@ const (
 	taskIntervalSyncActionBroadcast = 30 * time.Second                      // Default task time for cron jobs (seconds)
 	taskIntervalSyncActionP2P       = 35 * time.Second                      // Default task time for cron jobs (seconds)
 	taskIntervalSyncActionSync      = 40 * time.Second                      // Default task time for cron jobs (seconds)
+	taskIntervalTransactionCheck    = 60 * time.Second                      // Default task time for cron jobs (seconds)
 )
 
 // All the base models
@@ -108,6 +109,7 @@ const (
 	typeField            = "type"
 	xPubIDField          = "xpub_id"
 	xPubMetadataField    = "xpub_metadata"
+	blockHeightField     = "block_height"
 
 	// Universal statuses
 	statusCanceled   = "canceled"

--- a/model_transaction_config.go
+++ b/model_transaction_config.go
@@ -106,6 +106,12 @@ const (
 	ChangeStrategyNominations ChangeStrategy = "nominations"
 )
 
+// Types of Transaction actions
+const (
+	// TransactionActionCheck Get on-chain data about the transaction which have height == 0(IE: block hash, height, etc)
+	TransactionActionCheck = "check"
+)
+
 // ScriptOutput is the actual script record (could be several for one output record)
 type ScriptOutput struct {
 	Address    string `json:"address,omitempty"`  // Hex encoded locking script

--- a/tasks.go
+++ b/tasks.go
@@ -108,9 +108,5 @@ func taskCheckTransactions(ctx context.Context, logClient zLogger.GormLoggerInte
 
 	logClient.Info(ctx, "running check transaction(s) task...")
 
-	err := processTransactions(ctx, 10, opts...)
-	if err != nil {
-		return err
-	}
-	return nil
+	return processTransactions(ctx, 10, opts...)
 }

--- a/tasks.go
+++ b/tasks.go
@@ -102,3 +102,15 @@ func taskSyncTransactions(ctx context.Context, logClient zLogger.GormLoggerInter
 	}
 	return err
 }
+
+// taskCheckTransactions will check any transactions
+func taskCheckTransactions(ctx context.Context, logClient zLogger.GormLoggerInterface, opts ...ModelOps) error {
+
+	logClient.Info(ctx, "running check transaction(s) task...")
+
+	err := processTransactions(ctx, 10, opts...)
+	if err == nil || errors.Is(err, datastore.ErrNoResults) {
+		return nil
+	}
+	return err
+}

--- a/tasks.go
+++ b/tasks.go
@@ -109,8 +109,8 @@ func taskCheckTransactions(ctx context.Context, logClient zLogger.GormLoggerInte
 	logClient.Info(ctx, "running check transaction(s) task...")
 
 	err := processTransactions(ctx, 10, opts...)
-	if err == nil || errors.Is(err, datastore.ErrNoResults) {
-		return nil
+	if err != nil {
+		return err
 	}
-	return err
+	return nil
 }


### PR DESCRIPTION
Description
------------

- Added new task for transaction model which check if there are transactions with height 0 and then create request to miners to synchronize transactions.

When transaction have height 0?
If users is using method `AdminRecordTransaction` in go or js buxclient the transactions is the only created object (for example for recording STAS tokens in BUX). Without SyncTransaction it can not be synchronized. Added task provide a way to update information about this transactions