### PR TITLE
feat(BUX-180): remove option to use whatsonchain and nownodes for broadcasting

### DIFF
--- a/chainstate/broadcast.go
+++ b/chainstate/broadcast.go
@@ -101,16 +101,6 @@ func createActiveProviders(c *Client, txID, txHex string) []txBroadcastProvider 
 		}
 	}
 
-	if shouldBroadcastToWhatsOnChain(c) {
-		pvdr := whatsOnChainBroadcastProvider{txID: txID, txHex: txHex}
-		providers = append(providers, &pvdr)
-	}
-
-	if shouldBroadcastToNowNodes(c) {
-		pvdr := nowNodesBroadcastProvider{uniqueID: txID, txID: txID, txHex: txHex}
-		providers = append(providers, &pvdr)
-	}
-
 	if shouldBroadcastWithBroadcastClient(c) {
 		pvdr := broadcastClientProvider{txID: txID, txHex: txHex}
 		providers = append(providers, &pvdr)
@@ -122,15 +112,6 @@ func createActiveProviders(c *Client, txID, txHex string) []txBroadcastProvider 
 func shouldBroadcastWithMAPI(c *Client) bool {
 	return !utils.StringInSlice(ProviderMAPI, c.options.config.excludedProviders) &&
 		(c.Network() == MainNet || c.Network() == TestNet) // Only supported on main and test right now
-}
-
-func shouldBroadcastToWhatsOnChain(c *Client) bool {
-	return !utils.StringInSlice(ProviderWhatsOnChain, c.options.config.excludedProviders)
-}
-
-func shouldBroadcastToNowNodes(c *Client) bool {
-	return !utils.StringInSlice(ProviderNowNodes, c.options.config.excludedProviders) &&
-		c.NowNodes() != nil // Only if NowNodes is loaded (requires API key)
 }
 
 func shouldBroadcastWithBroadcastClient(c *Client) bool {

--- a/chainstate/broadcast_providers.go
+++ b/chainstate/broadcast_providers.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 
 	"github.com/bitcoin-sv/go-broadcast-client/broadcast"
-	"github.com/mrz1836/go-nownodes"
 	"github.com/tonicpow/go-minercraft/v2"
 )
 
@@ -66,83 +65,6 @@ func broadcastMAPI(ctx context.Context, client ClientInterface, miner *minercraf
 
 	// We got a potential real error message?
 	return errors.New(resp.Results.ResultDescription)
-}
-
-////
-
-// WhatsOnChain provider
-type whatsOnChainBroadcastProvider struct {
-	txID, txHex string
-}
-
-func (provider whatsOnChainBroadcastProvider) getName() string {
-	return ProviderWhatsOnChain
-}
-
-func (provider whatsOnChainBroadcastProvider) broadcast(ctx context.Context, c *Client) error {
-	return broadcastWhatsOnChain(ctx, c, provider.txID, provider.txHex)
-}
-
-// broadcastWhatsOnChain will broadcast a transaction to WhatsOnChain
-func broadcastWhatsOnChain(ctx context.Context, client ClientInterface, id, hex string) error {
-	debugLog(client, id, "executing broadcast request for "+ProviderWhatsOnChain)
-
-	txID, err := client.WhatsOnChain().BroadcastTx(ctx, hex)
-	if err != nil {
-
-		// Check error message (for success error message)
-		if doesErrorContain(err.Error(), broadcastSuccessErrors) {
-			return nil
-		}
-		return err
-	}
-
-	// Something went wrong - got back an id that does not match
-	if !strings.EqualFold(txID, id) {
-		return incorrectTxIDReturnedErr(txID, id)
-	}
-
-	// Success
-	return nil
-}
-
-////
-
-// NowNodes provider
-type nowNodesBroadcastProvider struct {
-	uniqueID, txID, txHex string
-}
-
-func (provider nowNodesBroadcastProvider) getName() string {
-	return ProviderNowNodes
-}
-
-// Broadcast using NowNodes
-func (provider nowNodesBroadcastProvider) broadcast(ctx context.Context, c *Client) error {
-	return broadcastNowNodes(ctx, c, provider.uniqueID, provider.txID, provider.txHex)
-}
-
-// broadcastNowNodes will broadcast a transaction to NowNodes
-func broadcastNowNodes(ctx context.Context, client ClientInterface, uniqueID, txID, hex string) error {
-	debugLog(client, txID, "executing broadcast request for "+ProviderNowNodes)
-
-	result, err := client.NowNodes().SendRawTransaction(ctx, nownodes.BSV, hex, uniqueID)
-	if err != nil {
-
-		// Check error message (for success error message)
-		if doesErrorContain(err.Error(), broadcastSuccessErrors) {
-			return nil
-		}
-		return err
-	}
-
-	// Something went wrong - got back an id that does not match
-	if !strings.EqualFold(result.Result, txID) {
-		return incorrectTxIDReturnedErr(result.Result, txID)
-	}
-
-	// Success
-	return nil
 }
 
 ////

--- a/chainstate/broadcast_test.go
+++ b/chainstate/broadcast_test.go
@@ -35,8 +35,6 @@ func TestClient_Broadcast_Success(t *testing.T) {
 		c := NewTestClient(
 			context.Background(), t,
 			WithMinercraft(&minerCraftBroadcastSuccess{}),
-			WithNowNodes(&nowNodesTxNotFound{}),         // Not found
-			WithWhatsOnChain(&whatsOnChainTxNotFound{}), // Not Found
 		)
 		providers, err := c.Broadcast(
 			context.Background(), broadcastExample1TxID, broadcastExample1TxHex, defaultBroadcastTimeOut,
@@ -51,97 +49,6 @@ func TestClient_Broadcast_Success(t *testing.T) {
 		assert.NotContains(t, miners, ProviderWhatsOnChain)
 		assert.NotContains(t, miners, ProviderNowNodes)
 	})
-
-	t.Run("broadcast - success (WhatsOnChain)", func(t *testing.T) {
-		c := NewTestClient(
-			context.Background(), t,
-			WithWhatsOnChain(&whatsOnChainBroadcastSuccess{}),
-			WithNowNodes(&nowNodesTxNotFound{}),     // Not Found
-			WithMinercraft(&minerCraftTxNotFound{}), // Not found
-		)
-		provider, err := c.Broadcast(
-			context.Background(), broadcastExample1TxID, broadcastExample1TxHex, defaultBroadcastTimeOut,
-		)
-		require.NoError(t, err)
-		assert.Equal(t, ProviderWhatsOnChain, provider)
-	})
-
-	t.Run("broadcast - success (NowNodes)", func(t *testing.T) {
-		c := NewTestClient(
-			context.Background(), t,
-			WithNowNodes(&nowNodesBroadcastSuccess{}),
-			WithWhatsOnChain(&whatsOnChainTxNotFound{}), // Not Found
-			WithMinercraft(&minerCraftTxNotFound{}),     // Not found
-		)
-		provider, err := c.Broadcast(
-			context.Background(), broadcastExample1TxID, broadcastExample1TxHex, defaultBroadcastTimeOut,
-		)
-		require.NoError(t, err)
-		assert.Equal(t, ProviderNowNodes, provider)
-	})
-
-	t.Run("broadcast - success (NowNodes timeouts)", func(t *testing.T) {
-		c := NewTestClient(
-			context.Background(), t,
-			WithNowNodes(&nowNodesBroadcastTimeout{}),         // Timeout
-			WithWhatsOnChain(&whatsOnChainBroadcastSuccess{}), // Success
-			WithMinercraft(&minerCraftBroadcastSuccess{}),     // Success
-		)
-		providers, err := c.Broadcast(
-			context.Background(), broadcastExample1TxID, broadcastExample1TxHex, defaultBroadcastTimeOut,
-		)
-		require.NoError(t, err)
-		miners := strings.Split(providers, ",")
-
-		assert.GreaterOrEqual(t, len(miners), 1)
-
-		assert.True(t, containsAtLeastOneElement(miners, minercraft.MinerTaal, minercraft.MinerMempool, minercraft.MinerGorillaPool, minercraft.MinerMatterpool, ProviderWhatsOnChain))
-
-		assert.NotContains(t, miners, ProviderNowNodes)
-	})
-
-	t.Run("broadcast - success (WhatsOnChain timeouts)", func(t *testing.T) {
-		c := NewTestClient(
-			context.Background(), t,
-			WithWhatsOnChain(&whatsOnChainBroadcastTimeout{}), // Timeout
-			WithNowNodes(&nowNodesBroadcastSuccess{}),         // Success
-			WithMinercraft(&minerCraftBroadcastSuccess{}),     // Success
-		)
-		providers, err := c.Broadcast(
-			context.Background(), broadcastExample1TxID, broadcastExample1TxHex, defaultBroadcastTimeOut,
-		)
-		require.NoError(t, err)
-		miners := strings.Split(providers, ",")
-
-		assert.GreaterOrEqual(t, len(miners), 1)
-
-		assert.True(t, containsAtLeastOneElement(miners, minercraft.MinerTaal, minercraft.MinerMempool, minercraft.MinerGorillaPool, minercraft.MinerMatterpool, ProviderNowNodes))
-
-		assert.NotContains(t, miners, ProviderWhatsOnChain)
-	})
-
-	t.Run("broadcast - success (mAPI timeouts)", func(t *testing.T) {
-		c := NewTestClient(
-			context.Background(), t,
-			WithMinercraft(&minerCraftBroadcastTimeout{}),     // Timeout
-			WithWhatsOnChain(&whatsOnChainBroadcastSuccess{}), // Success
-			WithNowNodes(&nowNodesBroadcastSuccess{}),         // Success
-		)
-		providers, err := c.Broadcast(
-			context.Background(), broadcastExample1TxID, broadcastExample1TxHex, defaultBroadcastTimeOut,
-		)
-		require.NoError(t, err)
-		miners := strings.Split(providers, ",")
-
-		assert.GreaterOrEqual(t, len(miners), 1)
-
-		assert.True(t, containsAtLeastOneElement(miners, ProviderWhatsOnChain, ProviderNowNodes))
-
-		assert.NotContains(t, miners, minercraft.MinerTaal)
-		assert.NotContains(t, miners, minercraft.MinerMempool)
-		assert.NotContains(t, miners, minercraft.MinerGorillaPool)
-		assert.NotContains(t, miners, minercraft.MinerMatterpool)
-	})
 }
 
 // TestClient_Broadcast_OnChain will test the method Broadcast()
@@ -152,36 +59,6 @@ func TestClient_Broadcast_OnChain(t *testing.T) {
 		c := NewTestClient(
 			context.Background(), t,
 			WithMinercraft(&minerCraftTxOnChain{}),
-			WithWhatsOnChain(&whatsOnChainTxNotFound{}), // Not Found
-			WithNowNodes(&nowNodesTxNotFound{}),         // Not Found
-		)
-		provider, err := c.Broadcast(
-			context.Background(), onChainExample1TxID, onChainExample1TxHex, defaultBroadcastTimeOut,
-		)
-		require.NoError(t, err)
-		assert.NotEmpty(t, provider)
-	})
-
-	t.Run("broadcast - tx already on-chain (WhatsOnChain)", func(t *testing.T) {
-		c := NewTestClient(
-			context.Background(), t,
-			WithWhatsOnChain(&whatsOnChainTxOnChain{}),
-			WithMinercraft(&minerCraftTxNotFound{}), // Not found
-			WithNowNodes(&nowNodesTxNotFound{}),     // Not Found
-		)
-		provider, err := c.Broadcast(
-			context.Background(), onChainExample1TxID, onChainExample1TxHex, defaultBroadcastTimeOut,
-		)
-		require.NoError(t, err)
-		assert.NotEmpty(t, provider)
-	})
-
-	t.Run("broadcast - tx already on-chain (NowNodes)", func(t *testing.T) {
-		c := NewTestClient(
-			context.Background(), t,
-			WithNowNodes(&nowNodesTxOnChain{}),
-			WithWhatsOnChain(&whatsOnChainTxNotFound{}), // Not Found
-			WithMinercraft(&minerCraftTxNotFound{}),     // Not found
 		)
 		provider, err := c.Broadcast(
 			context.Background(), onChainExample1TxID, onChainExample1TxHex, defaultBroadcastTimeOut,
@@ -199,39 +76,9 @@ func TestClient_Broadcast_InMempool(t *testing.T) {
 		c := NewTestClient(
 			context.Background(), t,
 			WithMinercraft(&minerCraftInMempool{}),
-			WithNowNodes(&nowNodesTxNotFound{}),         // Not Found
-			WithWhatsOnChain(&whatsOnChainTxNotFound{}), // Not Found
 		)
 		provider, err := c.Broadcast(
 			context.Background(), onChainExample1TxID, onChainExample1TxHex, defaultBroadcastTimeOut,
-		)
-		require.NoError(t, err)
-		assert.NotEmpty(t, provider)
-	})
-
-	t.Run("broadcast - in mempool (WhatsOnChain)", func(t *testing.T) {
-		c := NewTestClient(
-			context.Background(), t,
-			WithWhatsOnChain(&whatsOnChainInMempool{}),
-			WithNowNodes(&nowNodesTxNotFound{}),     // Not Found
-			WithMinercraft(&minerCraftTxNotFound{}), // Not found
-		)
-		provider, err := c.Broadcast(
-			context.Background(), broadcastExample1TxID, broadcastExample1TxHex, defaultBroadcastTimeOut,
-		)
-		require.NoError(t, err)
-		assert.NotEmpty(t, provider)
-	})
-
-	t.Run("broadcast - in mempool (NowNodes)", func(t *testing.T) {
-		c := NewTestClient(
-			context.Background(), t,
-			WithNowNodes(&nowNodeInMempool{}),
-			WithWhatsOnChain(&whatsOnChainTxNotFound{}), // Not found
-			WithMinercraft(&minerCraftTxNotFound{}),     // Not Found
-		)
-		provider, err := c.Broadcast(
-			context.Background(), broadcastExample1TxID, broadcastExample1TxHex, defaultBroadcastTimeOut,
 		)
 		require.NoError(t, err)
 		assert.NotEmpty(t, provider)
@@ -265,9 +112,7 @@ func TestClient_Broadcast(t *testing.T) {
 	t.Run("broadcast - all providers fail", func(t *testing.T) {
 		c := NewTestClient(
 			context.Background(), t,
-			WithNowNodes(&nowNodesTxNotFound{}),         // Not found
-			WithWhatsOnChain(&whatsOnChainTxNotFound{}), // Not found
-			WithMinercraft(&minerCraftTxNotFound{}),     // Not Found
+			WithMinercraft(&minerCraftTxNotFound{}), // Not Found
 		)
 		provider, err := c.Broadcast(
 			context.Background(), broadcastExample1TxID, broadcastExample1TxHex, defaultBroadcastTimeOut,


### PR DESCRIPTION
Context: 

1. As I understood from previous discussions we should focus on providing support for common/standarized API especially Arc (and for now still support for mApi).

2. Just as an extension to that, we have similar broadcasting support for Now Nodes, should we remove it also?

Answers:

1. Agreed

2. Agreed, we are specifically building on this software to avoid relying on a node. NowNodes is counter to this mission.