### PR TITLE
feat(BUX-243): empty implementation of ExecuteSimplifiedPaymentVerification

### DIFF
--- a/paymail_mocks_test.go
+++ b/paymail_mocks_test.go
@@ -41,3 +41,10 @@ func (m *mockServiceProvider) RecordTransaction(_ context.Context,
 	// Record the tx into your datastore layer
 	return nil, nil
 }
+
+// ExecuteSimplifiedPaymentVerification is a demo implementation of this interface
+func (m *mockServiceProvider) ExecuteSimplifiedPaymentVerification(ctx context.Context,
+	beedData *paymail.DecodedBEEF,
+) error {
+	return nil
+}

--- a/paymail_service_provider.go
+++ b/paymail_service_provider.go
@@ -180,6 +180,14 @@ func (p *PaymailDefaultServiceProvider) RecordTransaction(ctx context.Context,
 	}, nil
 }
 
+// ExecuteSimplifiedPaymentVerification is an empty implementation of ExecuteSimplifiedPaymentVerification
+// to support latest version of go-paymail
+func (m *PaymailDefaultServiceProvider) ExecuteSimplifiedPaymentVerification(ctx context.Context,
+	beedData *paymail.DecodedBEEF,
+) error {
+	return nil
+}
+
 func (p *PaymailDefaultServiceProvider) createPaymailInformation(ctx context.Context, alias, domain string, opts ...ModelOps) (paymailAddress *PaymailAddress, pubKey *derivedPubKey, err error) {
 	paymailAddress, err = getPaymailAddress(ctx, alias+"@"+domain, opts...)
 	if err != nil {


### PR DESCRIPTION
Implement ExecuteSimplifiedPaymentVerification for PaymailDefaultServiceProvider to support latest version of go-paymail.

fixes: 
`github.com/BuxOrg/bux ../../../../bux/client_internal.go:246:3: cannot use &PaymailDefaultServiceProvider{…} (value of type *PaymailDefaultServiceProvider) as server.PaymailServiceProvider value in argument to server.NewConfig: *PaymailDefaultServiceProvider does not implement server.PaymailServiceProvider (missing method ExecuteSimplifiedPaymentVerification) (exit status 1)`