### PR TITLE
fix(BUX-287): failed tests on local machine

### DIFF
--- a/chainstate/broadcast_test.go
+++ b/chainstate/broadcast_test.go
@@ -35,7 +35,8 @@ func TestClient_Broadcast(t *testing.T) {
 
 	t.Run("error - missing tx id", func(t *testing.T) {
 		// given
-		c := NewTestClient(context.Background(), t)
+		c := NewTestClient(context.Background(), t,
+			WithMinercraft(&MinerCraftBase{}))
 
 		// when
 		provider, err := c.Broadcast(
@@ -50,7 +51,8 @@ func TestClient_Broadcast(t *testing.T) {
 
 	t.Run("error - missing tx hex", func(t *testing.T) {
 		// given
-		c := NewTestClient(context.Background(), t)
+		c := NewTestClient(context.Background(), t,
+			WithMinercraft(&MinerCraftBase{}))
 
 		// when
 		provider, err := c.Broadcast(
@@ -105,6 +107,7 @@ func TestClient_Broadcast_BroadcastClient(t *testing.T) {
 			Build()
 		c := NewTestClient(
 			context.Background(), t,
+			WithMinercraft(&MinerCraftBase{}),
 			WithBroadcastClient(bc),
 		)
 

--- a/chainstate/client_test.go
+++ b/chainstate/client_test.go
@@ -51,6 +51,7 @@ func TestNewClient(t *testing.T) {
 		require.NotNil(t, customClient)
 		c, err := NewClient(
 			context.Background(),
+			WithMinercraft(&MinerCraftBase{}),
 			WithBroadcastClient(customClient),
 		)
 		require.NoError(t, err)
@@ -61,7 +62,7 @@ func TestNewClient(t *testing.T) {
 
 	t.Run("custom minercraft client", func(t *testing.T) {
 		customClient, err := minercraft.NewClient(
-			minercraft.DefaultClientOptions(), nil, "", nil, nil,
+			minercraft.DefaultClientOptions(), &http.Client{}, minercraft.Arc, nil, nil,
 		)
 		require.NoError(t, err)
 		require.NotNil(t, customClient)

--- a/chainstate/transaction_test.go
+++ b/chainstate/transaction_test.go
@@ -97,7 +97,6 @@ func TestClient_Transaction_MAPI(t *testing.T) {
 		assert.Equal(t, minerTaal.Name, info.Provider)
 		assert.Equal(t, minerTaal.MinerID, info.MinerID)
 	})
-
 }
 
 func TestClient_Transaction_BroadcastClient(t *testing.T) {
@@ -110,6 +109,7 @@ func TestClient_Transaction_BroadcastClient(t *testing.T) {
 			Build()
 		c := NewTestClient(
 			context.Background(), t,
+			WithMinercraft(&MinerCraftBase{}),
 			WithBroadcastClient(bc),
 		)
 
@@ -135,6 +135,7 @@ func TestClient_Transaction_BroadcastClient(t *testing.T) {
 			Build()
 		c := NewTestClient(
 			context.Background(), t,
+			WithMinercraft(&MinerCraftBase{}),
 			WithBroadcastClient(bc),
 			WithNetwork(StressTestNet),
 		)
@@ -161,6 +162,7 @@ func TestClient_Transaction_BroadcastClient(t *testing.T) {
 			Build()
 		c := NewTestClient(
 			context.Background(), t,
+			WithMinercraft(&MinerCraftBase{}),
 			WithBroadcastClient(bc),
 			WithNetwork(TestNet),
 		)
@@ -296,7 +298,8 @@ func TestClient_Transaction_MultipleClients_Fastest(t *testing.T) {
 
 	t.Run("error - missing id", func(t *testing.T) {
 		// given
-		c := NewTestClient(context.Background(), t)
+		c := NewTestClient(context.Background(), t,
+			WithMinercraft(&MinerCraftBase{}))
 
 		// when
 		info, err := c.QueryTransactionFastest(
@@ -311,7 +314,8 @@ func TestClient_Transaction_MultipleClients_Fastest(t *testing.T) {
 
 	t.Run("error - missing requirements", func(t *testing.T) {
 		// given
-		c := NewTestClient(context.Background(), t)
+		c := NewTestClient(context.Background(), t,
+			WithMinercraft(&MinerCraftBase{}))
 
 		// when
 		info, err := c.QueryTransactionFastest(


### PR DESCRIPTION
<!-- 
    Thank you for contributing to our project! Before you submit your Pull Request, please make sure you've completed the items in this checklist.
    Please check the boxes below by putting an x in the [ ] like so: [x]. You can do it right after creating the PR.
-->

# Pull Request Checklist

- [x] 📖 I created my PR using provided  : [CODE_STANDARDS](https://github.com/BuxOrg/bux/blob/main/.github/CODE_STANDARDS.md)
- [x] 📖 I have read the short Code of Conduct: [CODE_OF_CONDUCT](https://github.com/BuxOrg/bux/blob/main/.github/CODE_OF_CONDUCT.md)
- [x] 🏠 I tested my changes locally.
- [x] ✅ I have provided tests for my changes.
- [x] 📝 I have used conventional commits.
- [ ] 📗 I have updated any related documentation.
- [ ] 💾 PR was issued based on the Github or Jira issue.

<!-- 
## PR Title as Conventional Commit

Your PR title should also be a [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/). This will assist us in our release process and in assigning semantic version numbers to releases.
-->

<!-- 
## Related Tickets & Documents

If your changes relate to or close an issue, please include them below. We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For instance, having the text "closes #1234" would link the current pull request to issue number 1234. And when we merge the pull request, Github will automatically close the issue.

- Related Issue #
- Closes #
-->

<!--
## Feature/Issue Details

Your pull request should be tightly connected to a feature or issue. Ensure that you've covered all necessary pathways and there's a possibility to test code behavior following the issue description or feature specification.
-->

<img width="897" alt="Screenshot 2023-10-20 at 10 16 56" src="https://github.com/BuxOrg/bux/assets/123358309/f2eba1f2-3d4a-4be4-bd8d-e3a67d8744ea">

*Some of the tests require running redis, so you also need to run it on your machine to get the same result.