### PR TITLE
Chore(bux-000) make datastore quiet

### DIFF
--- a/client_options.go
+++ b/client_options.go
@@ -283,9 +283,11 @@ func WithLogger(customLogger *zerolog.Logger) ClientOps {
 			c.notifications.options = append(c.notifications.options, notifications.WithLogger(&notificationsLogger))
 
 			// Enable the logger on all external services
-			datastoreLogger := logging.CreateGormLoggerAdapter(customLogger, "datastore")
-			cachestoreLogger := logging.CreateGormLoggerAdapter(customLogger, "cachestore")
+			warnLvlLogger := customLogger.Level(zerolog.WarnLevel)
+			datastoreLogger := logging.CreateGormLoggerAdapter(&warnLvlLogger, "datastore")
 			c.dataStore.options = append(c.dataStore.options, datastore.WithLogger(&datastore.DatabaseLogWrapper{GormLoggerInterface: datastoreLogger}))
+
+			cachestoreLogger := logging.CreateGormLoggerAdapter(customLogger, "cachestore")
 			c.cacheStore.options = append(c.cacheStore.options, cachestore.WithLogger(cachestoreLogger))
 		}
 	}

--- a/client_options.go
+++ b/client_options.go
@@ -32,7 +32,7 @@ type ClientOps func(c *clientOptions)
 
 // defaultClientOptions will return an clientOptions struct with the default settings
 //
-// Useful for starting with the default and then modifying as neededs
+// Useful for starting with the default and then modifying as needed
 func defaultClientOptions() *clientOptions {
 	defaultLogger := logging.GetDefaultLogger()
 

--- a/definitions.go
+++ b/definitions.go
@@ -23,7 +23,7 @@ const (
 	dustLimit                      = uint64(1)         // Dust limit
 	mongoTestVersion               = "6.0.4"           // Mongo Testing Version
 	sqliteTestVersion              = "3.37.0"          // SQLite Testing Version (dummy version for now)
-	version                        = "v0.9.1"          // bux version
+	version                        = "v0.10.2"         // bux version
 )
 
 // All the base models


### PR DESCRIPTION
Datastore logs all executed queries at the info level, making it difficult to read logs.

If the logger is configured to log at the info level, we set up the Datastore logger to the warning level.

<!-- 
    Thank you for contributing to our project! Before you submit your Pull Request, please make sure you've completed the items in this checklist.
    Please check the boxes below by putting an x in the [ ] like so: [x]. You can do it right after creating the PR.
-->

# Pull Request Checklist

- [ ] 📖 I created my PR using provided  : [CODE_STANDARDS](https://github.com/BuxOrg/bux/blob/main/.github/CODE_STANDARDS.md)
- [ ] 📖 I have read the short Code of Conduct: [CODE_OF_CONDUCT](https://github.com/BuxOrg/bux/blob/main/.github/CODE_OF_CONDUCT.md)
- [ ] 🏠 I tested my changes locally.
- [ ] ✅ I have provided tests for my changes.
- [ ] 📝 I have used conventional commits.
- [ ] 📗 I have updated any related documentation.
- [ ] 💾 PR was issued based on the Github or Jira issue.

<!-- 
## PR Title as Conventional Commit

Your PR title should also be a [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/). This will assist us in our release process and in assigning semantic version numbers to releases.
-->

<!-- 
## Related Tickets & Documents

If your changes relate to or close an issue, please include them below. We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For instance, having the text "closes #1234" would link the current pull request to issue number 1234. And when we merge the pull request, Github will automatically close the issue.

- Related Issue #
- Closes #
-->

<!--
## Feature/Issue Details

Your pull request should be tightly connected to a feature or issue. Ensure that you've covered all necessary pathways and there's a possibility to test code behavior following the issue description or feature specification.
-->
